### PR TITLE
feat: enhance issue display with summary blocks and metadata

### DIFF
--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -206,12 +206,15 @@ export const searchGithubIssuesByEmbeddings = async (
         title: string;
         description: string;
         issue_url: string;
+        status: string | null;
+        milestone: string | null;
+        labels: string[] | null;
         rank: number;
       }[]
     >("*")
     .from(function () {
       // @ts-ignore does not like function and this.select...
-      this.select("title", "description", "issue_url", {
+      this.select("title", "description", "issue_url", "status", "milestone", "labels", {
         rank: knex.raw(`1 - (github_issues.embeddings <=> ?)`, [embeddings]),
       })
         .from("github_issues")


### PR DESCRIPTION
### TL;DR

Enhanced the UI for GitHub issue management with improved formatting, additional metadata, and confidence scoring.

### What changed?

- **Issue Drafting UI (cloudy008.ts)**:
  - Added a summary section showing the total number of drafted issues
  - Improved the layout with dividers between issues
  - Added a dedicated section to display issue labels
  - Restructured the blocks to separate summary and issue content

- **Issue Search UI (cloudy009.ts)**:
  - Added a summary section showing search results count
  - Enhanced issue display with emoji indicators and confidence ratings
  - Added metadata display for status, milestone, and labels
  - Implemented confidence scoring (high/medium/low) based on similarity rank

- **Search Functionality (db.ts)**:
  - Added search limits (3 results) and threshold (0.66)
  - Enhanced the returned data to include status, milestone, and labels
  - Added rank information to indicate search result relevance

### How to test?

1. Draft new issues using the agent and verify the improved UI with summary section and label display
2. Search for existing issues and check that:
   - Results show confidence ratings (High 💪, Medium 👌, Low 🤷‍♂️)
   - Each issue displays status, milestone, and labels
   - Only relevant results (above 0.66 threshold) are shown
   - Maximum of 3 results are displayed

### Why make this change?

This enhancement improves the user experience by providing more context and better organization of GitHub issues. The confidence scoring helps users quickly assess the relevance of search results, while the additional metadata (status, milestone, labels) provides important context without requiring users to click through to GitHub. The summary sections make it easier to understand the overall results at a glance.